### PR TITLE
Add default AWS prefix for AWS.EnvironmentCredentials

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -65,7 +65,7 @@ const credentialsFromProfile = (profileKey) => {
 }
 
 const credentialsFromEnvironment = () => {
-  let credentials = new AWS.EnvironmentCredentials('AWS')
+  let credentials = new AWS.EnvironmentCredentials("AWS")
 
   if (!credentials.accessKeyId) {
     throw new KnownError(`Environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are not set`)

--- a/lib/aws.js
+++ b/lib/aws.js
@@ -65,7 +65,7 @@ const credentialsFromProfile = (profileKey) => {
 }
 
 const credentialsFromEnvironment = () => {
-  let credentials = new AWS.EnvironmentCredentials()
+  let credentials = new AWS.EnvironmentCredentials('AWS')
 
   if (!credentials.accessKeyId) {
     throw new KnownError(`Environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are not set`)


### PR DESCRIPTION
Thanks for adding this, makes CI usage so much easier!

AWS.EnvironmentCredentials wants a prefix passed in even for the default - https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/EnvironmentCredentials.html

Without one it looks for `ACCESS_KEY_ID` and `SECRET_ACCESS_KEY`